### PR TITLE
Test Elm Platform semver against supported range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
+install:
+  - npm install -g elm@0.17.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "0.10"
 install:
   - npm install -g elm@0.17.0
+  - npm install

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "yeoman-generator"
   ],
   "dependencies": {
-    "yeoman-generator": "^0.19.0",
     "chalk": "^1.0.0",
+    "semver": "^5.2.0",
+    "yeoman-generator": "^0.19.0",
     "yosay": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
#31

Added semver package from npm to handle validation of Elm Platform semver during generator install process.
Added validateEnv function to check Elm Platform semver before files are installed and throw various exceptions if the version isn't within appropriate bounds.
Fixed a spelling error: 'Skiped installation' -> 'Skipped installation'
Adjusted inconsistent line spacing above writing function.